### PR TITLE
Configure routes and responses for lessons and groups

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,6 +11,13 @@ class ApplicationController < ActionController::Base
   end
 
   def respond_with_meta(resource, **args)
-    render json: resource, meta: { server_time: Time.zone.now.to_i }.merge(args)
+    resource_class = resource.class.name.split('::')
+    if resource_class[1] == "ActiveRecord_Relation"
+      resource = { resource_class[0].downcase.pluralize => resource }
+    else
+      resource = { resource_class[0].downcase => resource }
+    end
+
+    render json: resource.merge(meta: { server_time: Time.zone.now.to_i }.merge(args))
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,4 +9,8 @@ class ApplicationController < ActionController::Base
       return
     end
   end
+
+  def respond_with_meta(resource, **args)
+    render json: resource, meta: { server_time: Time.zone.now.to_i }.merge(args)
+  end
 end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,7 +1,31 @@
 class GroupsController < ApplicationController
 
   def index
-    respond_with_meta({'man': 'hi'})
+    faculties = Faculty.all
+    groups = Group.all.order(course: :asc)
+    faculties_with_courses = faculties.map do |faculty|
+      correct_groups = groups.select{ |group| group.faculty_id == faculty.id }
+      courses = get_courses(correct_groups)
+      faculty.attributes.merge!(courses: courses)
+    end
+
+    respond_with_meta({ faculties: faculties_with_courses })
+  end
+
+
+  private
+
+
+  def get_courses(groups)
+    min_course = 1
+    max_course = 6
+    courses = {}
+
+    (min_course..max_course).each do |course_number|
+      course_groups = groups.select{ |group| group.course == course_number }
+      courses[course_number] = course_groups
+    end
+    courses
   end
 
 end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -3,12 +3,12 @@ class GroupsController < ApplicationController
   def index
     faculties = Faculty.all
     groups = Group.all.order(course: :asc)
+
     faculties_with_courses = faculties.map do |faculty|
-      correct_groups = groups.select{ |group| group.faculty_id == faculty.id }
-      courses = get_courses(correct_groups)
+      faculty_groups = groups.select{ |group| group.faculty_id == faculty.id }
+      courses = get_courses(faculty_groups)
       faculty.attributes.merge!(courses: courses)
     end
-
     respond_with_meta({ faculties: faculties_with_courses })
   end
 
@@ -22,8 +22,8 @@ class GroupsController < ApplicationController
     courses = {}
 
     (min_course..max_course).each do |course_number|
-      course_groups = groups.select{ |group| group.course == course_number }
-      courses[course_number] = course_groups
+      groups_by_course = groups.select{ |group| group.course == course_number }
+      courses[course_number] = groups_by_course
     end
     courses
   end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -1,0 +1,7 @@
+class GroupsController < ApplicationController
+
+  def index
+    respond_with_meta({'man': 'hi'})
+  end
+
+end

--- a/app/controllers/lessons_controller.rb
+++ b/app/controllers/lessons_controller.rb
@@ -7,29 +7,14 @@ class LessonsController < ApplicationController
       return
     end
     lessons = group.lessons
-    is_group_by_weeks = params[:group_by_weeks] == "true"
-
-    if params.key?(:from) && params.key?(:to)
-      custom_serialization(lessons, is_group_by_weeks, "accept \'from\' and \'to\' params")
-    elsif params.key?(:from)
-      custom_serialization(lessons, is_group_by_weeks, "accept only \'from\' param")
-    elsif params.key?(:to)
-      custom_serialization(lessons, is_group_by_weeks, "accept only \'to\' param")
-    elsif params.key?(:week)
-      if params[:week].count == 1
-        custom_serialization(lessons, is_group_by_weeks, "accept #{params[:week].first} week")
-      elsif params[:week].count == 2
-        custom_serialization(lessons, is_group_by_weeks, "accept #{params[:week].first}-#{params[:week].last} week")
-      end
-    end
   end
 
 
   private
 
 
-  def custom_serialization(lessons, is_group_by_weeks, accept_method)
-    render json: { group_by_weeks: is_group_by_weeks, custom_serialization: accept_method, lessons: lessons }
+  def lesson_params
+    params.permit(:from, :to, :group_by_weeks, week: [])
   end
 
 end

--- a/app/controllers/lessons_controller.rb
+++ b/app/controllers/lessons_controller.rb
@@ -1,0 +1,33 @@
+class LessonsController < ApplicationController
+
+  def show
+    group = Group.find_by(name: params[:group_name])
+
+    if params.key?(:from) && params.key?(:to)
+      lessons = { 'custom serialization' => 'between entered \'from\' and entered \'to\' dates' }
+    elsif params.key?(:from)
+      lessons = { 'custom serialization' => 'between entered \'from\' and default \'to\' dates' }
+    elsif params.key?(:to)
+      lessons = { 'custom serialization' => 'between default \'from\' and entered \'to\' dates' }
+    elsif params.key?(:week)
+      if params[:week].count == 1
+        lessons = { 'custom serialization' => "should return #{params[:week].first} week" }
+      elsif params[:week].count == 2
+        lessons = { 'custom serialization' => "should return #{params[:week].first}-#{params[:week].last} week" }
+      end
+    end
+    group_by_weeks(lessons) if params[:group_by_weeks] == "1"
+
+    group_with_lessons = group.attributes.merge!(lessons: lessons)
+    respond_with_meta(group_with_lessons)
+  end
+
+
+  private
+
+
+  def group_by_weeks(lessons)
+    lessons['group_by_weeks'] = "should return groups array by week number"
+  end
+
+end

--- a/app/controllers/lessons_controller.rb
+++ b/app/controllers/lessons_controller.rb
@@ -1,6 +1,10 @@
 class LessonsController < ApplicationController
 
   def show
+    if lesson_params[:weeks].present? && lesson_params[:dates].present?
+      render json: { errors: "Forbidden, select weeks or dates" }, status: 403
+      return
+    end
     group = Group.find_by(name: params[:group_name])
     if group.blank?
       render json: { errors: "Group #{params[:group_name]} Not Found" }, status: 404
@@ -14,7 +18,7 @@ class LessonsController < ApplicationController
 
 
   def lesson_params
-    params.permit(:from, :to, :group_by_weeks, week: [])
+    params.permit(:group_by_weeks, dates: [:from, :to], weeks: [])
   end
 
 end

--- a/app/controllers/lessons_controller.rb
+++ b/app/controllers/lessons_controller.rb
@@ -2,32 +2,34 @@ class LessonsController < ApplicationController
 
   def show
     group = Group.find_by(name: params[:group_name])
+    if group.blank?
+      render json: { errors: "Group #{params[:group_name]} Not Found" }, status: 404
+      return
+    end
+    lessons = group.lessons
+    is_group_by_weeks = params[:group_by_weeks] == "true"
 
     if params.key?(:from) && params.key?(:to)
-      lessons = { 'custom serialization' => 'between entered \'from\' and entered \'to\' dates' }
+      custom_serialization(lessons, is_group_by_weeks, "accept \'from\' and \'to\' params")
     elsif params.key?(:from)
-      lessons = { 'custom serialization' => 'between entered \'from\' and default \'to\' dates' }
+      custom_serialization(lessons, is_group_by_weeks, "accept only \'from\' param")
     elsif params.key?(:to)
-      lessons = { 'custom serialization' => 'between default \'from\' and entered \'to\' dates' }
+      custom_serialization(lessons, is_group_by_weeks, "accept only \'to\' param")
     elsif params.key?(:week)
       if params[:week].count == 1
-        lessons = { 'custom serialization' => "should return #{params[:week].first} week" }
+        custom_serialization(lessons, is_group_by_weeks, "accept #{params[:week].first} week")
       elsif params[:week].count == 2
-        lessons = { 'custom serialization' => "should return #{params[:week].first}-#{params[:week].last} week" }
+        custom_serialization(lessons, is_group_by_weeks, "accept #{params[:week].first}-#{params[:week].last} week")
       end
     end
-    group_by_weeks(lessons) if params[:group_by_weeks] == "1"
-
-    group_with_lessons = group.attributes.merge!(lessons: lessons)
-    respond_with_meta(group_with_lessons)
   end
 
 
   private
 
 
-  def group_by_weeks(lessons)
-    lessons['group_by_weeks'] = "should return groups array by week number"
+  def custom_serialization(lessons, is_group_by_weeks, accept_method)
+    render json: { group_by_weeks: is_group_by_weeks, custom_serialization: accept_method, lessons: lessons }
   end
 
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,4 +4,5 @@ Rails.application.routes.draw do
   root to: 'timetables#show'
 
   resources :groups, only: [:index]
+  resources :lessons, only: [:show], param: :group_name
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,6 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 
   root to: 'timetables#show'
+
+  resources :groups, only: [:index]
 end


### PR DESCRIPTION
GroupsController
GET '/groups'
#index
response with all faculties, courses and groups

LessonsControlller
GET '/lessons/:group_name' (where group_name is 'КСМ-1' etc.)
#show
accepted params:
:from(date) - a date to start timetable info
:to(date) - a date to end timetable info
– or – 
:week(array, integer, 1..2 values) - a week(or weeks range) to display timetable info
e.g. 
week: [1] - return first week
week: [10, 12] - return 10-12 weeks
and optional:
:group_by_weeks(boolean) - groups array by week number